### PR TITLE
Revert "prefix to only generate for some tables"

### DIFF
--- a/sp_CRUDGen.sql
+++ b/sp_CRUDGen.sql
@@ -79,8 +79,7 @@ GO
 **********************************************************************************************************************/
 ALTER PROCEDURE dbo.sp_CRUDGen (
     @GenerateStoredProcedures  bit           = 0                        /* 0 = Will only create the generated T-SQL to create the stored procedures, 1 = Will also create the stored procedures */
-   ,@SchemaTableOrViewName     nvarchar(200) = NULL                     /* NULL = Generate all tables with prefix & views, [SCHEMA.TABLEORVIEWNAME] or [TABLEORVIEWNAME] for just one table or view */
-   ,@PrefixTable               nvarchar(5)   = NULL                     /* NULL = Generate all tables, not empty will generate for tables with prefix */
+   ,@SchemaTableOrViewName     nvarchar(200) = NULL                     /* NULL = Generate all tables & views, [SCHEMA.TABLEORVIEWNAME] or [TABLEORVIEWNAME] for just one table or view */
    ,@GenerateCreate            bit           = 1                        /* 1 = Generate the Create stored procedure, 0 = Will not generate the Create stored procedure */
    ,@GenerateCreateMultiple    bit           = 1                        /* 1 = Generate the Create stored procedure, 0 = Will not generate the Create stored procedure */
    ,@GenerateRead              bit           = 1                        /* 1 = Generate the Read stored procedure, 0 = Will not generate the Read stored procedure */
@@ -385,7 +384,6 @@ AS
             )                                       AS P
         WHERE
             (T.name = @TableName OR @TableName IS NULL)
-		AND ((T.name like @PrefixTable + '%' OR @PrefixTable IS NULL) AND T.name <> 'sysdiagrams')
         AND (S.name = @SchemaName OR @SchemaName IS NULL)
         ORDER BY
             S.name


### PR DESCRIPTION
Reverts kevinmartintech/sp_CRUDGen#33

Going to roll this back for now. Will need to account for table schema when a table name exists in multiple schemas like a temporal table in a 'history' schema and the base table in the 'dbo' schema.